### PR TITLE
De-activate the macro in Release mode through NDEBUG

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -362,7 +362,7 @@ class DebugOutput {
 
 }  // namespace dbg_macro
 
-#ifndef DBG_MACRO_DISABLE
+#if !defined(DBG_MACRO_DISABLE) && !defined(NDEBUG)
 // We use a variadic macro to support commas inside expressions (e.g.
 // initializer lists):
 #define dbg(...)                                                     \


### PR DESCRIPTION
Many developers make use of Debug and Release builds. For example, with CMake we can specify the build type, which will define de NDEBUG macro if we're in Release mode. Therefore, using that macro to define the dbg one can be very convinient to many developers instead of having to explictly define the DBG_MACRO_DISABLE.