### PR TITLE
Combine `std::cerr` writes into single call

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -341,17 +341,19 @@ class DebugOutput {
     std::stringstream stream_value;
     const bool print_expr_and_type = pretty_print(stream_value, ref);
 
-    std::cerr << ansi(ANSI_DEBUG) << "[" << m_filepath << ":" << m_line << " ("
+    std::stringstream output;
+    output << ansi(ANSI_DEBUG) << "[" << m_filepath << ":" << m_line << " ("
               << m_function_name << ")] " << ansi(ANSI_RESET);
     if (print_expr_and_type) {
-      std::cerr << ansi(ANSI_EXPRESSION) << m_expression << ansi(ANSI_RESET)
+      output << ansi(ANSI_EXPRESSION) << m_expression << ansi(ANSI_RESET)
                 << " = ";
     }
-    std::cerr << ansi(ANSI_VALUE) << stream_value.str() << ansi(ANSI_RESET);
+    output << ansi(ANSI_VALUE) << stream_value.str() << ansi(ANSI_RESET);
     if (print_expr_and_type) {
-      std::cerr << " (" << ansi(ANSI_TYPE) << type << ansi(ANSI_RESET) << ")";
+      output << " (" << ansi(ANSI_TYPE) << type << ansi(ANSI_RESET) << ")";
     }
-    std::cerr << std::endl;
+    output << std::endl;
+    std::cerr << output.str();
 
     return std::forward<T>(value);
   }


### PR DESCRIPTION
For multithreading-compatibility, combine all `std::cerr` writes into a single write.

closes #30