### PR TITLE
Made colorized output disabled by default on windows. Colorized output can be enabled with DBG_MACRO_COLORIZED_OUTPUT_WINDOWS.

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -61,7 +61,11 @@ inline bool isColorizedOutputEnabled() {
 }
 #else
 inline bool isColorizedOutputEnabled() {
+#ifdef DBG_MACRO_COLORIZED_OUTPUT_WINDOWS
   return true;
+#else
+  return false;
+#endif
 }
 #endif
 


### PR DESCRIPTION
ANSI colors on windows are disabled by default.

Colorized output should also be disabled on windows by default to avoid the printing of unwanted control characters.

I've added the define "DBG_MACRO_COLORIZED_OUTPUT_WINDOWS" for this purpose.