### PR TITLE
Adds empty dbg calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ int main() {
 
   dbg("this line is executed");  // [example.cpp:23 (main)] this line is executed
 
+  dbg();  //[example.cpp:28 (main)] dbg call reached.
+
   factorial(4);
 
   return 0;

--- a/dbg.h
+++ b/dbg.h
@@ -565,6 +565,10 @@ T&& identity(T&& t) {
 // Intermediate macro "chooser"
 #define dbg_x(x, A, Func, ...) Func
 
+// Macro to be called and used by user
+// First param must be blank to allow for 0 argument function
+#define dbg(...) dbg_x(, ##__VA_ARGS__, dbg_VA(__VA_ARGS__), dbg_0())
+
 #ifndef DBG_MACRO_DISABLE
 
 // Empty macro, prints "dbg call reached."
@@ -579,10 +583,6 @@ T&& identity(T&& t) {
   dbg::DebugOutput(__FILE__, __LINE__, __func__, #__VA_ARGS__) \
       .print(dbg::type_name<decltype(__VA_ARGS__)>(), (__VA_ARGS__))
 
-// Macro to be called and used by user
-// First param must be blank to allow for 0 argument function
-#define dbg(...) dbg_x(, ##__VA_ARGS__, dbg_VA(__VA_ARGS__), dbg_0())
-
 #else
 
 // Empty macro
@@ -590,10 +590,6 @@ T&& identity(T&& t) {
 
 // Normal macro, passes value through
 #define dbg_VA(...) dbg::identity(__VA_ARGS__)
-
-// Macro called by user
-// First param must be blank
-#define dbg(...) dbg_x(, ##__VA_ARGS__, dbg_VA(__VA_ARGS__), dbg_0())
 
 #endif  // DBG_MACRO_DISABLE
 

--- a/dbg.h
+++ b/dbg.h
@@ -562,14 +562,39 @@ T&& identity(T&& t) {
 
 }  // namespace dbg
 
+// Intermediate macro "chooser"
+#define dbg_x(x, A, Func, ...) Func
+
 #ifndef DBG_MACRO_DISABLE
+
+// Empty macro, prints "dbg call reached."
+#define dbg_0()                                            \
+  dbg::DebugOutput(__FILE__, __LINE__, __func__, "") \
+      .print(dbg::type_name<decltype("")>(), ("dbg call reached."))
+
+// The normal macro, prints expression and type
 // We use a variadic macro to support commas inside expressions (e.g.
 // initializer lists):
-#define dbg(...)                                               \
+#define dbg_VA(...)                                                  \
   dbg::DebugOutput(__FILE__, __LINE__, __func__, #__VA_ARGS__) \
       .print(dbg::type_name<decltype(__VA_ARGS__)>(), (__VA_ARGS__))
+
+// Macro to be called and used by user
+// First param must be blank to allow for 0 argument function
+#define dbg(...) dbg_x(, ##__VA_ARGS__, dbg_VA(__VA_ARGS__), dbg_0())
+
 #else
-#define dbg(...) dbg::identity(__VA_ARGS__)
+
+// Empty macro
+#define dbg_0()
+
+// Normal macro, passes value through
+#define dbg_VA(...) dbg::identity(__VA_ARGS__)
+
+// Macro called by user
+// First param must be blank
+#define dbg(...) dbg_x(, ##__VA_ARGS__, dbg_VA(__VA_ARGS__), dbg_0())
+
 #endif  // DBG_MACRO_DISABLE
 
 #endif  // DBG_MACRO_DBG_H

--- a/dbg.h
+++ b/dbg.h
@@ -572,14 +572,14 @@ T&& identity(T&& t) {
 #ifndef DBG_MACRO_DISABLE
 
 // Empty macro, prints "dbg call reached."
-#define dbg_0()                                            \
+#define dbg_0()                                      \
   dbg::DebugOutput(__FILE__, __LINE__, __func__, "") \
       .print(dbg::type_name<decltype("")>(), ("dbg call reached."))
 
 // The normal macro, prints expression and type
 // We use a variadic macro to support commas inside expressions (e.g.
 // initializer lists):
-#define dbg_VA(...)                                                  \
+#define dbg_VA(...)                                            \
   dbg::DebugOutput(__FILE__, __LINE__, __func__, #__VA_ARGS__) \
       .print(dbg::type_name<decltype(__VA_ARGS__)>(), (__VA_ARGS__))
 

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -25,6 +25,8 @@ int main() {
   dbg("this line is executed");  // [example.cpp:23 (main)] this line is
                                  // executed
 
+  dbg();  //[example.cpp:28 (main)] dbg call reached.
+
   factorial(4);
 
   return 0;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -86,6 +86,10 @@ int main() {
   dbg(test_c_chararray);
   dbg(test_string);
 
+  dbg("====== empty calls");
+
+  dbg();
+
   dbg("====== r-values, literals, constants, etc.");
 
   dbg(42);


### PR DESCRIPTION
This allows users to call `dbg()` with no arguments to print out dummy text "dbg call reached".  
Works with or without `DBG_MACRO_DISABLE` being defined.    
Closes #64 