### PR TITLE
Integral number formatting support

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -95,11 +95,15 @@ static constexpr size_t SUFFIX_LENGTH = sizeof(">(void)") - 1;
 
 template <typename T>
 struct print_formatted {
-  static_assert(std::is_integral<T>::value,
-                "Only integral types are supported.");
+  static_assert(std::is_integral<T>::value && std::is_unsigned<T>::value,
+                "Only unsigned integral types are supported.");
 
   print_formatted(T value, int numeric_base)
       : inner(value), base(numeric_base) {}
+
+  operator T() const {
+    return inner;
+  }
 
   const char* prefix() const {
     switch (base) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -225,7 +225,7 @@ int main() {
   assert_eq(pretty_print(dbg::hex(hex_4)), "0x1234567890ABCDEF");
 
   uint32_t oct_1 = 01234567;
-  assert_eq(pretty_print(dbg::oct(oct_1)), "01234567");
+  assert_eq(pretty_print(dbg::oct(oct_1)), "0o1234567");
 
 #if __cplusplus >= 201703L
   assert_eq(pretty_print(std::make_optional<bool>(false)), "{false}");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -224,6 +224,15 @@ int main() {
   uint64_t hex_3 = 0x1234567890ABCDEF;
   assert_eq(pretty_print(dbg::hex(hex_3)), "0x1234567890ABCDEF");
 
+  int8_t hex_4 = -0x80;
+  assert_eq(pretty_print(dbg::hex(hex_4)), "-0x80");
+
+  int8_t hex_5 = 0x7F;
+  assert_eq(pretty_print(dbg::hex(hex_5)), "0x7F");
+
+  int64_t hex_6 = -0x8000000000000000;
+  assert_eq(pretty_print(dbg::hex(hex_6)), "-0x8000000000000000");
+
   uint32_t oct_1 = 01234567;
   assert_eq(pretty_print(dbg::oct(oct_1)), "0o1234567");
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -221,8 +221,8 @@ int main() {
   uint16_t hex_2 = 0xAB12;
   assert_eq(pretty_print(dbg::hex(hex_2)), "0xAB12");
 
-  uint64_t hex_4 = 0x1234567890ABCDEF;
-  assert_eq(pretty_print(dbg::hex(hex_4)), "0x1234567890ABCDEF");
+  uint64_t hex_3 = 0x1234567890ABCDEF;
+  assert_eq(pretty_print(dbg::hex(hex_3)), "0x1234567890ABCDEF");
 
   uint32_t oct_1 = 01234567;
   assert_eq(pretty_print(dbg::oct(oct_1)), "0o1234567");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -28,7 +28,7 @@ void assert_eq(const L& lhs, const R& rhs) {
 template <typename T>
 std::string pretty_print(T&& value) {
   std::stringstream stream;
-  dbg_macro::pretty_print(stream, std::forward<T>(value));
+  dbg::pretty_print(stream, std::forward<T>(value));
   return stream.str();
 }
 
@@ -214,6 +214,19 @@ int main() {
   s_shared_ptr_expected << shared_ptr_address << " (use_count = 2)";
   assert_eq(s_shared_ptr_expected.str(), pretty_print(dummy_shared_ptr));
 
+  // dbg::hex and dbg::oct
+  uint8_t hex_1 = 0xA7;
+  assert_eq(pretty_print(dbg::hex(hex_1)), "0xA7");
+
+  uint16_t hex_2 = 0xAB12;
+  assert_eq(pretty_print(dbg::hex(hex_2)), "0xAB12");
+
+  uint64_t hex_4 = 0x1234567890ABCDEF;
+  assert_eq(pretty_print(dbg::hex(hex_4)), "0x1234567890ABCDEF");
+
+  uint32_t oct_1 = 01234567;
+  assert_eq(pretty_print(dbg::oct(oct_1)), "01234567");
+
 #if __cplusplus >= 201703L
   assert_eq(pretty_print(std::make_optional<bool>(false)), "{false}");
   std::optional<int> empty_optional;
@@ -227,7 +240,7 @@ int main() {
 
   dbg("====== type_name<T>() tests");
 
-  using namespace dbg_macro;
+  using namespace dbg;
 
   assert_eq(type_name<void>(), "void");
   assert_eq(type_name<int>(), "int");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -227,6 +227,9 @@ int main() {
   uint32_t oct_1 = 01234567;
   assert_eq(pretty_print(dbg::oct(oct_1)), "0o1234567");
 
+  assert_eq(dbg(dbg::hex(hex_2)), hex_2);
+  assert_eq(dbg(dbg::hex(hex_2)) + 1, hex_2 + 1);
+
 #if __cplusplus >= 201703L
   assert_eq(pretty_print(std::make_optional<bool>(false)), "{false}");
   std::optional<int> empty_optional;


### PR DESCRIPTION
attempts to solve #61 

This let's us write
```c++
uint32_t x = /* … */;

dbg(dbg::hex(x));

dbg(dbg::oct(x));
```

The values currently print out like this:
![image](https://user-images.githubusercontent.com/4209276/71297298-3a0f7180-2383-11ea-9225-160d8bcb8ae0.png)
