### PR TITLE
Adds printing of std::pair

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -200,6 +200,11 @@ std::string get_type_name(type_tag<std::vector<T, std::allocator<T>>>) {
   return "std::vector<" + type_name<T>() + ">";
 }
 
+template <typename T1, typename T2>
+std::string get_type_name(type_tag<std::pair<T1, T2>>) {
+  return "std::pair<" + type_name<T1>() + ", " + type_name<T2>() + ">";
+}
+
 template <typename T>
 inline std::string get_type_name(type_tag<print_formatted<T>>) {
   return type_name<T>();
@@ -456,6 +461,16 @@ pretty_print(std::ostream& stream, Enum const& value) {
 
 inline bool pretty_print(std::ostream& stream, const std::string& value) {
   stream << '"' << value << '"';
+  return true;
+}
+
+template <typename T1, typename T2>
+inline bool pretty_print(std::ostream& stream, const std::pair<T1, T2>& value) {
+  stream << "{";
+  pretty_print(stream, value.first);
+  stream << ", ";
+  pretty_print(stream, value.second);
+  stream << "}";
   return true;
 }
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -74,6 +74,13 @@ TEST_CASE("pretty_print") {
     CHECK(pretty_print(std::tuple<int, bool>{42, false}) == "{42, false}");
   }
 
+  SECTION("std::pair") {
+    CHECK(pretty_print(std::pair<int, bool>{13, true})  == "{13, true}");
+
+    std::pair<std::pair<bool, int>, bool> pair_of_pairs{{false, 17}, true};
+    CHECK(pretty_print(pair_of_pairs)  == "{{false, 17}, true}");
+  }
+
   SECTION("std::unique_ptr") {
     auto dummy_unique_ptr = std::unique_ptr<int>{new int{42}};
     const void* unique_ptr_address = static_cast<void*>(dummy_unique_ptr.get());

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -98,6 +98,9 @@ int main() {
   int dummy_int_array[] = {11, 22, 33};
   dbg(dummy_int_array);
 
+  dbg("====== std::tuple and std::pair");
+  dbg(std::pair<std::string, int>{"Hello", 7});
+
   dbg("====== function name tests");
 
   class user_defined_class {


### PR DESCRIPTION
Closes #70 

@sharkdp please let me know if this is a good way to properly implement this. I have not done this bit before.   
My reasoning for `type_name` was I noticed that a string passed to the pair would have their type printed as `std::__cxx11::basic_string` and I was not entirely sure how you were dealing with this. I also did the recursive `pretty_print` to allow for pairs in pairs.

Again, haven't done this bit so let me know of the optimal code. : )