### PR TITLE
Change readme example namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you want to modify the type name that is printed by `dbg(…)`, you can add a
 `get_type_name` overload:
 ```c++
 // Customization point for type information
-namespace dbg_macro {
+namespace dbg {
     std::string get_type_name(type_tag<bool>) {
         return "truth value";
     }


### PR DESCRIPTION
This was changed in a recent pr (#68) but the readme was neglected.