### PR TITLE
Add dbg::type<T>() helper to directly print type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ const uint32_t secret = 12648430;
 dbg(dbg::hex(secret));
 ```
 
+### Printing type names
+
+`dbg(…)` already prints the type for each value in parenthesis (see screenshot above). But
+sometimes you just want to print a type (maybe because you don't have a value for that type).
+In this case, you can use the `dbg::type<T>()` helper to pretty-print a given type `T`.
+For example:
+```c++
+template <typename T>
+void my_function_template() {
+  using MyDependentType = typename std::remove_reference<T>::type&&;
+  dbg(dbg::type<MyDependentType>());
+}
+```
+
 ### Customization
 
 If you want `dbg(…)` to work for your custom datatype, you can simply overload `operator<<` for

--- a/dbg.h
+++ b/dbg.h
@@ -326,6 +326,15 @@ struct has_ostream_operator : is_detected<ostream_operator_t, T> {};
 
 }  // namespace detail
 
+// Helper to dbg(…)-print types
+template <typename T>
+struct print_type {};
+
+template <typename T>
+print_type<T> type() {
+  return print_type<T>{};
+}
+
 // Specializations of "pretty_print"
 
 template <typename T>
@@ -457,6 +466,12 @@ inline bool pretty_print(std::ostream& stream,
   }
 
   return true;
+}
+
+template <typename T>
+inline bool pretty_print(std::ostream& stream, const print_type<T>&) {
+  stream << type_name<T>();
+  return false;
 }
 
 template <typename Container>

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -121,4 +121,8 @@ int main() {
     dbg("called from within a lambda!");
     return x;
   }(42);
+
+  dbg("====== type names without a value");
+  using IsSame = std::is_same<uint8_t, char>::type;
+  dbg(dbg::type<IsSame>());
 }


### PR DESCRIPTION
`dbg(…)` already prints the type for each value in parenthesis (see README screenshot). But
sometimes you just want to print a type (maybe because you don't have a value for that type).
In this case, you can use the `dbg::type<T>()` helper to pretty-print a given type `T`.
For example:
```c++
template <typename T>
void my_function_template() {
  using MyDependentType = typename std::remove_reference<T>::type&&;
  dbg(dbg::type<MyDependentType>());
}
``` 


Another example:
```c++
using IsSame = std::is_same<uint8_t, char>::type;
dbg(dbg::type<IsSame>());
```
prints:
```
[..macro/tests/demo.cpp:127 (main)] std::integral_constant<bool, false>
```