### PR TITLE
Add some control of floating point formatting

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -446,7 +446,7 @@ inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type
 pretty_print(std::ostream& stream, const std::complex<T>& value) {
   std::stringstream sl;
   sl.copyfmt(g_floating_point_format);
-  sl << value;
+  sl << "(" << value.real() << ", " << value.imag() << ")";
   stream << sl.str();
   return true;
 }

--- a/dbg.h
+++ b/dbg.h
@@ -85,7 +85,8 @@ inline bool isColorizedOutputEnabled() {
 struct time {};
 
 /**
- * The global stream object which is used to control the formatting of floating point numbers.
+ * The global stream object which is used to control the formatting of floating
+ * point numbers.
  */
 static std::stringstream g_floating_point_format{};
 
@@ -431,23 +432,23 @@ inline bool pretty_print(std::ostream& stream, const char* const& value) {
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value,bool>::type
-pretty_print(std::ostream& stream, const T& value){
-    std::stringstream sl;
-    sl.copyfmt(g_floating_point_format);
-    sl << value;
-    stream << sl.str();
-    return true;
+inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+pretty_print(std::ostream& stream, const T& value) {
+  std::stringstream sl;
+  sl.copyfmt(g_floating_point_format);
+  sl << value;
+  stream << sl.str();
+  return true;
 }
 
 template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value,bool>::type
-pretty_print(std::ostream& stream, const std::complex<T>& value){
-    std::stringstream sl;
-    sl.copyfmt(g_floating_point_format);
-    sl << value;
-    stream << sl.str();
-    return true;
+inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+pretty_print(std::ostream& stream, const std::complex<T>& value) {
+  std::stringstream sl;
+  sl.copyfmt(g_floating_point_format);
+  sl << value;
+  stream << sl.str();
+  return true;
 }
 
 template <size_t Idx>

--- a/dbg.h
+++ b/dbg.h
@@ -51,6 +51,7 @@ License (MIT):
 #include <tuple>
 #include <type_traits>
 #include <vector>
+#include <complex>
 
 #ifdef DBG_MACRO_UNIX
 #include <unistd.h>
@@ -432,6 +433,16 @@ inline bool pretty_print(std::ostream& stream, const char* const& value) {
 template <typename T>
 inline typename std::enable_if<std::is_floating_point<T>::value,bool>::type
 pretty_print(std::ostream& stream, const T& value){
+    std::stringstream sl;
+    sl.copyfmt(g_floating_point_format);
+    sl << value;
+    stream << sl.str();
+    return true;
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value,bool>::type
+pretty_print(std::ostream& stream, const std::complex<T>& value){
     std::stringstream sl;
     sl.copyfmt(g_floating_point_format);
     sl << value;

--- a/dbg.h
+++ b/dbg.h
@@ -83,6 +83,11 @@ inline bool isColorizedOutputEnabled() {
 
 struct time {};
 
+/**
+ * The global stream object which is used to control the formatting of floating point numbers.
+ */
+static std::stringstream g_floating_point_format{};
+
 namespace pretty_function {
 
 // Compiler-agnostic version of __PRETTY_FUNCTION__ and constants to
@@ -361,7 +366,8 @@ inline void pretty_print(std::ostream&, const T&, std::false_type) {
 
 template <typename T>
 inline typename std::enable_if<!detail::is_container<const T&>::value &&
-                                   !std::is_enum<T>::value,
+                                   !std::is_enum<T>::value &&
+                                   !std::is_floating_point<T>::value,
                                bool>::type
 pretty_print(std::ostream& stream, const T& value) {
   pretty_print(stream, value,
@@ -421,6 +427,16 @@ template <>
 inline bool pretty_print(std::ostream& stream, const char* const& value) {
   stream << '"' << value << '"';
   return true;
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value,bool>::type
+pretty_print(std::ostream& stream, const T& value){
+    std::stringstream sl;
+    sl.copyfmt(g_floating_point_format);
+    sl << value;
+    stream << sl.str();
+    return true;
 }
 
 template <size_t Idx>

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -107,23 +107,21 @@ int main() {
   dbg(dbg::bin(static_cast<uint8_t>(negative_five))); // two's complement:
 
   dbg("====== floating point formatting");
-  {
-      const double x = 0.123456789012345678;
-      const std::complex<double> z{123,x};
+  const double x = 0.123456789012345678;
+  const std::complex<double> z{123, x};
 
-      dbg::g_floating_point_format << std::setprecision(10);
-      dbg(x);
-      dbg::g_floating_point_format << std::setprecision(20);
-      dbg(x);
-      dbg::g_floating_point_format << std::setprecision(12) << std::scientific;
-      dbg(x);
-      dbg(z);
+  dbg::g_floating_point_format << std::setprecision(10);
+  dbg(x);
+  dbg::g_floating_point_format << std::setprecision(20);
+  dbg(x);
+  dbg::g_floating_point_format << std::setprecision(12) << std::scientific;
+  dbg(x);
+  dbg(z);
 
-      dbg("default formatting:");
-      dbg::g_floating_point_format = decltype(dbg::g_floating_point_format){};
-      dbg(x); 
-      dbg(z); 
-  }
+  dbg("default formatting:");
+  dbg::g_floating_point_format = decltype(dbg::g_floating_point_format){};
+  dbg(x);
+  dbg(z);
 
   dbg("====== std::tuple and std::pair");
   dbg(std::tuple<std::string, int, float>{"Hello", 7, 3.14f});

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -106,6 +106,25 @@ int main() {
   dbg(dbg::bin(negative_five));
   dbg(dbg::bin(static_cast<uint8_t>(negative_five))); // two's complement:
 
+  dbg("====== floating point formatting");
+  {
+      const double x = 0.123456789012345678;
+      const std::complex<double> z{123,x};
+
+      dbg::g_floating_point_format << std::setprecision(10);
+      dbg(x);
+      dbg::g_floating_point_format << std::setprecision(20);
+      dbg(x);
+      dbg::g_floating_point_format << std::setprecision(12) << std::scientific;
+      dbg(x);
+      dbg(z);
+
+      dbg("default formatting:");
+      dbg::g_floating_point_format = decltype(dbg::g_floating_point_format){};
+      dbg(x); 
+      dbg(z); 
+  }
+
   dbg("====== std::tuple and std::pair");
   dbg(std::tuple<std::string, int, float>{"Hello", 7, 3.14f});
   dbg(std::pair<std::string, int>{"Hello", 7});


### PR DESCRIPTION
This allows users to customize the output of floating point types by adjusting the flags of a stream in the same way as one normally would.

I also added the equivalent support for std::complex of floating point types in a C++11-compatible way (this would not require copying the code in C++17).