### PR TITLE
Add metainformation for dbg::type<T>()

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -524,6 +524,24 @@ inline bool pretty_print(std::ostream& stream,
 template <typename T>
 inline bool pretty_print(std::ostream& stream, const print_type<T>&) {
   stream << type_name<T>();
+
+  stream << " [sizeof: " << sizeof(T) << " byte, ";
+
+  stream << "trivial: ";
+  if (std::is_trivial<T>::value) {
+    stream << "yes";
+  } else {
+    stream << "no";
+  }
+
+  stream << ", standard layout: ";
+  if (std::is_standard_layout<T>::value) {
+    stream << "yes";
+  } else {
+    stream << "no";
+  }
+  stream << "]";
+
   return false;
 }
 

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -104,7 +104,7 @@ int main() {
 
   int8_t negative_five = -5;
   dbg(dbg::bin(negative_five));
-  dbg(dbg::bin(static_cast<uint8_t>(negative_five))); // two's complement:
+  dbg(dbg::bin(static_cast<uint8_t>(negative_five)));
 
   dbg("====== std::tuple and std::pair");
   dbg(std::tuple<std::string, int, float>{"Hello", 7, 3.14f});
@@ -121,6 +121,7 @@ int main() {
 
   class user_defined_class {
    public:
+    user_defined_class() {}
     void some_method(int x) { dbg(x); }
   };
   user_defined_class{}.some_method(42);
@@ -132,9 +133,20 @@ int main() {
 
   dbg("====== type names without a value");
   using IsSame = std::is_same<uint8_t, char>::type;
+
+  struct user_defined_trivial_type {
+    int32_t a;
+    bool b;
+  };
+
   dbg(dbg::type<IsSame>());
+  dbg(dbg::type<int32_t>());
+  dbg(dbg::type<const int32_t>());
+  dbg(dbg::type<int32_t*>());
+  dbg(dbg::type<int32_t&>());
+  dbg(dbg::type<user_defined_trivial_type>());
+  dbg(dbg::type<user_defined_class>());
 
   dbg("====== timestamp");
   dbg(dbg::time());
-
 }


### PR DESCRIPTION
```
[..macro/tests/demo.cpp:142 (main)] std::integral_constant<bool, false> [sizeof: 1 byte, trivial: yes, standard layout: yes]
[..macro/tests/demo.cpp:143 (main)] int [sizeof: 4 byte, trivial: yes, standard layout: yes]
[..macro/tests/demo.cpp:144 (main)] const int [sizeof: 4 byte, trivial: yes, standard layout: yes]
[..macro/tests/demo.cpp:145 (main)] int* [sizeof: 8 byte, trivial: yes, standard layout: yes]
[..macro/tests/demo.cpp:146 (main)] int& [sizeof: 4 byte, trivial: no, standard layout: no]
[..macro/tests/demo.cpp:147 (main)] main()::user_defined_trivial_type [sizeof: 8 byte, trivial: yes, standard layout: yes]
[..macro/tests/demo.cpp:148 (main)] main()::user_defined_class [sizeof: 1 byte, trivial: no, standard layout: yes]
```