### PR TITLE
Add support for string_view, adjust order of pretty_print functions

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -545,32 +545,6 @@ inline bool pretty_print(std::ostream& stream, const print_type<T>&) {
   return false;
 }
 
-template <typename Container>
-inline typename std::enable_if<detail::is_container<const Container&>::value,
-                               bool>::type
-pretty_print(std::ostream& stream, const Container& value) {
-  stream << "{";
-  const size_t size = detail::size(value);
-  const size_t n = std::min(size_t{10}, size);
-  size_t i = 0;
-  using std::begin;
-  using std::end;
-  for (auto it = begin(value); it != end(value) && i < n; ++it, ++i) {
-    pretty_print(stream, *it);
-    if (i != n - 1) {
-      stream << ", ";
-    }
-  }
-
-  if (size > n) {
-    stream << ", ...";
-    stream << " size:" << size;
-  }
-
-  stream << "}";
-  return true;
-}
-
 template <typename Enum>
 inline typename std::enable_if<std::is_enum<Enum>::value, bool>::type
 pretty_print(std::ostream& stream, Enum const& value) {
@@ -584,6 +558,15 @@ inline bool pretty_print(std::ostream& stream, const std::string& value) {
   stream << '"' << value << '"';
   return true;
 }
+
+#if DBG_MACRO_CXX_STANDARD >= 17
+
+inline bool pretty_print(std::ostream& stream, const std::string_view& value) {
+  stream << '"' << value << '"';
+  return true;
+}
+
+#endif
 
 template <typename T1, typename T2>
 inline bool pretty_print(std::ostream& stream, const std::pair<T1, T2>& value) {
@@ -621,6 +604,32 @@ inline bool pretty_print(std::ostream& stream,
 }
 
 #endif
+
+template <typename Container>
+inline typename std::enable_if<detail::is_container<const Container&>::value,
+                               bool>::type
+pretty_print(std::ostream& stream, const Container& value) {
+  stream << "{";
+  const size_t size = detail::size(value);
+  const size_t n = std::min(size_t{10}, size);
+  size_t i = 0;
+  using std::begin;
+  using std::end;
+  for (auto it = begin(value); it != end(value) && i < n; ++it, ++i) {
+    pretty_print(stream, *it);
+    if (i != n - 1) {
+      stream << ", ";
+    }
+  }
+
+  if (size > n) {
+    stream << ", ...";
+    stream << " size:" << size;
+  }
+
+  stream << "}";
+  return true;
+}
 
 template <typename T, typename... U>
 struct last {

--- a/dbg.h
+++ b/dbg.h
@@ -562,7 +562,7 @@ inline bool pretty_print(std::ostream& stream, const std::string& value) {
 #if DBG_MACRO_CXX_STANDARD >= 17
 
 inline bool pretty_print(std::ostream& stream, const std::string_view& value) {
-  stream << '"' << value << '"';
+  stream << '"' << value.data() << '"';
   return true;
 }
 

--- a/dbg.h
+++ b/dbg.h
@@ -562,7 +562,7 @@ inline bool pretty_print(std::ostream& stream, const std::string& value) {
 #if DBG_MACRO_CXX_STANDARD >= 17
 
 inline bool pretty_print(std::ostream& stream, const std::string_view& value) {
-  stream << '"' << value.data() << '"';
+  stream << '"' << std::string(value) << '"';
   return true;
 }
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -103,7 +103,7 @@ TEST_CASE("pretty_print") {
 
   #if DBG_MACRO_CXX_STANDARD >= 17
     SECTION("std::string_view") {
-    std::string_view x{"foo"};
+    std::string_view x{"foooo", 3}; // should only print 3 characters
     std::string_view y{"bar"};
     CHECK(pretty_print(x) == "\"foo\"");
     CHECK(pretty_print(std::make_pair(x, y)) == "{\"foo\", \"bar\"}");

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -11,6 +11,7 @@
 #if DBG_MACRO_CXX_STANDARD >= 17
 #include <optional>
 #include <variant>
+#include <string_view>
 #endif
 
 #include <dbg.h>
@@ -99,6 +100,15 @@ TEST_CASE("pretty_print") {
     CHECK(pretty_print(x) == "\"foo\"");
     CHECK(pretty_print(std::make_pair(x, y)) == "{\"foo\", \"bar\"}");
   }
+
+  #if DBG_MACRO_CXX_STANDARD >= 17
+    SECTION("std::string_view") {
+    std::string_view x{"foo"};
+    std::string_view y{"bar"};
+    CHECK(pretty_print(x) == "\"foo\"");
+    CHECK(pretty_print(std::make_pair(x, y)) == "{\"foo\", \"bar\"}");
+  }
+  #endif
 
   SECTION("nested containers") {
     std::vector<std::vector<int>> vec_of_vec_of_ints{{1, 2}, {3, 4, 5}};

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -11,6 +11,7 @@
 #if DBG_MACRO_CXX_STANDARD >= 17
 #include <optional>
 #include <variant>
+#include <string_view>
 #endif
 
 #include <dbg.h>
@@ -117,8 +118,10 @@ int main() {
 #if DBG_MACRO_CXX_STANDARD >= 17
   dbg("====== Sum types");
   dbg(std::make_optional<bool>(false));
-
   dbg((std::variant<int, std::string>{"test"}));
+
+  dbg("======= std::string_view");
+  dbg(std::string_view{"test"});
 #endif
 
   dbg("====== function name tests");


### PR DESCRIPTION
This PR mainly:
 
* Add specialization for pretty printing of `std::string_view`, avoiding it to be recognized as a container type and printed as something like `{'t', 'e', 's', 't'}`.
* Adjust the order or pretty print functions so that the specializations for sum types such as `std::variant` and container types comes last. Otherwise calling `pretty_print` to something like `std::pair<std::string_view, std::string_view>` still gives output like `{{'t', 'e', 's', 't'}, {'t', 'e', 's', 't'}}`, maybe due to the template resolution order of C++ (which I am not very familiar with). Change the order could solve this.