### PR TITLE
Fix: fixed conflict with std::min on MSVC

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -611,7 +611,7 @@ inline typename std::enable_if<detail::is_container<const Container&>::value,
 pretty_print(std::ostream& stream, const Container& value) {
   stream << "{";
   const size_t size = detail::size(value);
-  const size_t n = std::min(size_t{10}, size);
+  const size_t n = (std::min)(size_t{10}, size);
   size_t i = 0;
   using std::begin;
   using std::end;


### PR DESCRIPTION
Simple fix, instead of force user to write
#define NOMINMAX
Please refer this question(first answer)
https://stackoverflow.com/questions/13416418/define-nominmax-using-stdmin-max/13420838