### PR TITLE
Draft of fixes needed for supporting variadic templates

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -749,20 +749,23 @@ class DebugOutput {
 
   template <typename... T>
   auto print(std::initializer_list<expr_t> exprs,
-             std::initializer_list<std::string> types,
              T&&... values) -> last_t<T...> {
+    // I don't know how to tell which parameters are from variadic template, and
+    // which are usual separate arguments
     if (exprs.size() != sizeof...(values)) {
       std::cerr
           << m_location << ansi(ANSI_WARN)
           << "The number of arguments mismatch, please check unprotected comma"
+          /* << std::endl */
+          /* << exprs.size() << " " << sizeof...(values) */
           << ansi(ANSI_RESET) << std::endl;
     }
-    return print_impl(exprs.begin(), types.begin(), std::forward<T>(values)...);
+    return print_impl(exprs.begin(), std::forward<T>(values)...);
   }
 
  private:
   template <typename T>
-  T&& print_impl(const expr_t* expr, const std::string* type, T&& value) {
+  T&& print_impl(const expr_t* expr, T&& value) {
     const T& ref = value;
     std::stringstream stream_value;
     const bool print_expr_and_type = pretty_print(stream_value, ref);
@@ -774,7 +777,7 @@ class DebugOutput {
     }
     output << ansi(ANSI_VALUE) << stream_value.str() << ansi(ANSI_RESET);
     if (print_expr_and_type) {
-      output << " (" << ansi(ANSI_TYPE) << *type << ansi(ANSI_RESET) << ")";
+      output << " (" << ansi(ANSI_TYPE) << dbg::type_name<decltype(value)>() << ansi(ANSI_RESET) << ")";
     }
     output << std::endl;
     std::cerr << output.str();
@@ -784,11 +787,10 @@ class DebugOutput {
 
   template <typename T, typename... U>
   auto print_impl(const expr_t* exprs,
-                  const std::string* types,
                   T&& value,
                   U&&... rest) -> last_t<T, U...> {
-    print_impl(exprs, types, std::forward<T>(value));
-    return print_impl(exprs + 1, types + 1, std::forward<U>(rest)...);
+    print_impl(exprs, std::forward<T>(value));
+    return print_impl(exprs + 1, std::forward<U>(rest)...);
   }
 
   const char* ansi(const char* code) const {
@@ -885,10 +887,38 @@ auto identity(T&&, U&&... u) -> last_t<U...> {
 
 #define dbg(...)                                    \
   dbg::DebugOutput(__FILE__, __LINE__, __func__)    \
-      .print({DBG_MAP(DBG_STRINGIFY, __VA_ARGS__)}, \
-             {DBG_MAP(DBG_TYPE_NAME, __VA_ARGS__)}, __VA_ARGS__)
+      .print({DBG_MAP(DBG_STRINGIFY, __VA_ARGS__)}, __VA_ARGS__)
 #else
 #define dbg(...) dbg::identity(__VA_ARGS__)
 #endif  // DBG_MACRO_DISABLE
 
 #endif  // DBG_MACRO_DBG_H
+
+
+/* #include "dbg.h" */
+/* #include <iostream> */
+
+/* using namespace std; */
+
+/* template <typename... T> */
+/* void test(T&& ...args) { */
+/*   dbg('v', args..., 'v'); */
+/* }; */
+
+/* int main(void) */
+/* { */
+/*   // Works */
+/*   cout << endl << "dbg(1)" << endl; */
+/*   dbg(1); */
+/*   int v = 0; */
+/*   // Works */
+/*   cout << endl << "dbg(v)" << endl; */
+/*   dbg(v); */
+/*   // Works */
+/*   cout << endl << "test(v)" << endl; */
+/*   test(v); */
+/*   // Well, really doesn't work well */
+/*   cout << endl << "test(v, v)" << endl; */
+/*   test(v, 1); */
+/*   return 0; */
+/* } */


### PR DESCRIPTION
Hi, this pull request is a draft regarding #109.
So far it compiles and works when used with the variadic template, but it has some problems. 
In particular, the problem occurs [here](https://github.com/anstadnik/dbg-macro/blob/ca501cdf48667f2d8d25707ab1baeb2aedd389ed/dbg.h#L750-L764). I haven't yet came up with a solution on how to separate variadic packs from the actual arguments. My guess would be to try to change [this](https://github.com/anstadnik/dbg-macro/blob/ca501cdf48667f2d8d25707ab1baeb2aedd389ed/dbg.h#L888-L890) to something like:
```cpp
#define dbg(...)                                    \
  DBG_MAP(dbg::DebugOutput(__FILE__, __LINE__, __func__)    \
      .print(DBG_STRINGIFY(__VA_ARGS__), __VA_ARGS__))
```
This way it will call the print separately for each argument, and in my head it looks somewhat similar to
```cpp
template <typename... T>
void test(T&& ...args) {
  dbg('v', args..., 1);
};

int main(void)
{
  test(v, 1);
  return 0;
}
```
converting to
```cpp
dbg::DebugOutput("potato.cpp", 42, "test")    \
      .print("v", 'v'), \
dbg::DebugOutput("potato.cpp", 42, "test")    \
      .print("args...", args...), \
dbg::DebugOutput("potato.cpp", 42, "test")    \
      .print("1", 1)
```
, and after that it will be processed accordingly in the print function.
It will require creating a `DBG_MAP` function for 2 arguments, but will make print function much easier, and will remove the need in hacks with `initializer_list`.