### PR TITLE
Support for STL Container adapters

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -784,7 +784,7 @@ pretty_print(std::ostream& stream, ContainerAdapter value) {
   std::vector<typename ContainerAdapter::value_type> elements;
   elements.reserve(n);
   for (size_t i = 0; i < n; ++i) {
-    elements.push_back(std::move(detail::pop(value)));
+    elements.push_back(detail::pop(value));
   }
   std::reverse(elements.begin(), elements.end());
 

--- a/dbg.h
+++ b/dbg.h
@@ -780,16 +780,25 @@ pretty_print(std::ostream& stream, ContainerAdapter value) {
   stream << "{";
   const size_t size = detail::size(value);
   const size_t n = std::min(size_t{10}, size);
+
+  std::vector<typename ContainerAdapter::value_type> elements;
+  elements.reserve(n);
   for (size_t i = 0; i < n; ++i) {
-    pretty_print(stream, detail::pop(value));
+    elements.push_back(std::move(detail::pop(value)));
+  }
+  std::reverse(elements.begin(), elements.end());
+
+  if (size > n) {
+    stream << "..., ";
+  }
+  for (size_t i = 0; i < n; ++i) {
+    pretty_print(stream, elements[i]);
     if (i != n - 1) {
       stream << ", ";
     }
   }
-
   if (size > n) {
-    stream << ", ...";
-    stream << " size:" << size;
+    stream << " (size:" << size << ")";
   }
 
   stream << "}";

--- a/dbg.h
+++ b/dbg.h
@@ -475,9 +475,9 @@ inline typename std::enable_if<detail::is_container<const Container&>::value,
 pretty_print(std::ostream& stream, const Container& value);
 
 template <typename ContainerAdapter>
-inline std::enable_if_t<
+inline typename std::enable_if<
     detail::is_container_adapter<const ContainerAdapter&>::value,
-    bool>
+    bool>::type
 pretty_print(std::ostream& stream, ContainerAdapter value);
 
 // Specializations of "pretty_print"
@@ -773,9 +773,9 @@ pretty_print(std::ostream& stream, const Container& value) {
 }
 
 template <typename ContainerAdapter>
-inline std::enable_if_t<
+inline typename std::enable_if<
     detail::is_container_adapter<const ContainerAdapter&>::value,
-    bool>
+    bool>::type
 pretty_print(std::ostream& stream, ContainerAdapter value) {
   stream << "{";
   const size_t size = detail::size(value);

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -120,6 +120,24 @@ TEST_CASE("pretty_print") {
           "{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ... size:14}");
   }
 
+  SECTION("container adapters") {
+    CHECK(pretty_print(std::priority_queue<int>()) == "{}");
+    CHECK(pretty_print(std::stack<int>({1, 2, 3})) == "{3, 2, 1}");
+    CHECK(pretty_print(std::queue<int>({9, 8, 7})) == "{9, 8, 7}");
+    CHECK(pretty_print(std::stack<int>(
+              {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14})) ==
+          "{14, 13, 12, 11, 10, 9, 8, 7, 6, 5, ... size:14}");
+  }
+
+  SECTION("compound container adapters") {
+    std::priority_queue<std::pair<int,int>> pq_of_pairs;
+    pq_of_pairs.push({-3, 4});
+    pq_of_pairs.push({-3, 7});
+    pq_of_pairs.push({2, -8});
+    pq_of_pairs.push({-1, 9});
+    CHECK(pretty_print(pq_of_pairs) == "{{2, -8}, {-1, 9}, {-3, 7}, {-3, 4}}");
+  }
+
   SECTION("std::string") {
     std::string x = "foo";
     std::string y = "bar";

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -122,20 +122,20 @@ TEST_CASE("pretty_print") {
 
   SECTION("container adapters") {
     CHECK(pretty_print(std::priority_queue<int>()) == "{}");
-    CHECK(pretty_print(std::stack<int>({1, 2, 3})) == "{3, 2, 1}");
-    CHECK(pretty_print(std::queue<int>({9, 8, 7})) == "{9, 8, 7}");
+    CHECK(pretty_print(std::stack<int>({1, 2, 3})) == "{1, 2, 3}");
+    CHECK(pretty_print(std::queue<int>({9, 8, 7})) == "{7, 8, 9}");
     CHECK(pretty_print(std::stack<int>(
               {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14})) ==
-          "{14, 13, 12, 11, 10, 9, 8, 7, 6, 5, ... size:14}");
+          "{..., 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 (size:14)}");
   }
 
   SECTION("compound container adapters") {
-    std::priority_queue<std::pair<int,int>> pq_of_pairs;
+    std::priority_queue<std::pair<int, int>> pq_of_pairs;
     pq_of_pairs.push({-3, 4});
     pq_of_pairs.push({-3, 7});
     pq_of_pairs.push({2, -8});
     pq_of_pairs.push({-1, 9});
-    CHECK(pretty_print(pq_of_pairs) == "{{2, -8}, {-1, 9}, {-3, 7}, {-3, 4}}");
+    CHECK(pretty_print(pq_of_pairs) == "{{-3, 4}, {-3, 7}, {-1, 9}, {2, -8}}");
   }
 
   SECTION("std::string") {
@@ -164,7 +164,8 @@ TEST_CASE("pretty_print") {
     std::vector<std::pair<std::string, int>> vector_of_pairs = {
         {"30+2", 32}, {"30-2", 28}, {"30*2", 60}};
 
-    CHECK(pretty_print(vector_of_pairs) == "{{\"30+2\", 32}, {\"30-2\", 28}, {\"30*2\", 60}}");
+    CHECK(pretty_print(vector_of_pairs) ==
+          "{{\"30+2\", 32}, {\"30-2\", 28}, {\"30*2\", 60}}");
 
     std::tuple<std::vector<int>> tuple_with_vector{{1, 2, 3}};
     CHECK(pretty_print(tuple_with_vector) == "{{1, 2, 3}}");

--- a/tests/demo.cpp
+++ b/tests/demo.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <stack>
+#include <queue>
 
 #if DBG_MACRO_CXX_STANDARD >= 17
 #include <optional>
@@ -102,6 +104,17 @@ int main() {
 
   int dummy_int_array[] = {11, 22, 33};
   dbg(dummy_int_array);
+
+  dbg("====== container adapters");
+
+  std::stack<int> dummy_stack({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  dbg(dummy_stack);
+
+  std::priority_queue<std::pair<int,int>> dummy_pqueue;
+  dummy_pqueue.push({-3, 7});
+  dummy_pqueue.push({2, -8});
+  dummy_pqueue.push({-1, 9});
+  dbg(dummy_pqueue);
 
   dbg("====== integer formatting");
   dbg(dbg::hex(42));


### PR DESCRIPTION
Fixes #125

Adapters are detected by checking existence of underlying container using `container_type`. `pop` operation is specialised for each of the adapters (`std::stack`, `std::queue` and `std::priority_queue`) to remove and return the top/front element.

Have extended tests and demos as well.