### PR TITLE
[Bugfix] Incorrect typename for multidimensional c-style arrays

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -224,21 +224,21 @@ inline std::string get_type_name(type_tag<std::string>) {
 
 template <typename T>
 typename std::enable_if<(std::rank<T>::value == 1), std::string>::type
-get_dim() {
+get_array_dim() {
   return "[" + std::to_string(std::extent<T>::value) + "]";
 }
 
 template <typename T>
 typename std::enable_if<(std::rank<T>::value > 1), std::string>::type
-get_dim() {
+get_array_dim() {
   return "[" + std::to_string(std::extent<T>::value) + "]" +
-         get_dim<typename std::remove_extent<T>::type>();
+         get_array_dim<typename std::remove_extent<T>::type>();
 }
 
 template <typename T>
 typename std::enable_if<(std::rank<T>::value > 0), std::string>::type
 get_type_name(type_tag<T>) {
-  return type_name<typename std::remove_all_extents<T>::type>() + " " + get_dim<T>();
+  return type_name<typename std::remove_all_extents<T>::type>() + get_array_dim<T>();
 }
 
 template <typename T, size_t N>

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -280,6 +280,14 @@ TEST_CASE("type_name") {
     CHECK(type_name<float>() == "float");
   }
 
+  SECTION("C-style arrays") {
+    CHECK(type_name<int[3]>() ==
+          (std::is_same<int, int32_t>::value ? "int32_t [3]" : "int [3]"));
+    CHECK(type_name<char[1][2][3]>() == "char [1][2][3]");
+    double a[] = {5, 4, 3, 2, 1};
+    CHECK(type_name<decltype(a)>() == "double [5]");
+  }
+
   SECTION("const and volatile") {
     CHECK(type_name<const char>() == "const char");
     CHECK(type_name<volatile char>() == "volatile char");

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -282,10 +282,10 @@ TEST_CASE("type_name") {
 
   SECTION("C-style arrays") {
     CHECK(type_name<int[3]>() ==
-          (std::is_same<int, int32_t>::value ? "int32_t [3]" : "int [3]"));
-    CHECK(type_name<char[1][2][3]>() == "char [1][2][3]");
+          (std::is_same<int, int32_t>::value ? "int32_t[3]" : "int[3]"));
+    CHECK(type_name<char[1][2][3]>() == "char[1][2][3]");
     double a[] = {5, 4, 3, 2, 1};
-    CHECK(type_name<decltype(a)>() == "double [5]");
+    CHECK(type_name<decltype(a)>() == "double[5]");
   }
 
   SECTION("const and volatile") {


### PR DESCRIPTION
Fixes a bug introduced in [cf4ad54](https://github.com/sharkdp/dbg-macro/pull/128/commits/cf4ad54c12c7c91e2417b2188011da7326fa121a) which caused dimensions of multidimensional arrays to be formatted in reverse order.

Buggy output
---
```cpp
int a[1][2][3];
dbg(a);  // ... (int32_t [3] [2] [1])
```

Have extended tests for C-style arrays
