### PR TITLE
Make sure _MSC_VER is defined when used

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -625,7 +625,7 @@ inline bool pretty_print(std::ostream& stream, const time&) {
   const auto us =
       duration_cast<microseconds>(now.time_since_epoch()).count() % 1000000;
   const auto hms = system_clock::to_time_t(now);
-#if _MSC_VER >= 1600
+#if defined(_MSC_VER) && _MSC_VER >= 1600
   struct tm t;
   localtime_s(&t, &hms);
   const std::tm* tm = &t;


### PR DESCRIPTION
Otherwise this raises a warning under `-Wundef`:

```
error: '_MSC_VER' is not defined, evaluates to 0 [-Werror,-Wundef]
#if _MSC_VER >= 1600
    ^
```