### PR TITLE
Output multiple arguments on a single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,7 @@ int main() {
 
 ### Multiple arguments
 
-You can pass multiple arguments to the `dbg(…)` macro. The output of
-`dbg(x, y, z)` is same as `dbg(x); dbg(y); dbg(z);`:
+You can pass multiple arguments to the `dbg(…)` macro. This will output all expressions on a single line.
 ``` c++
 dbg(42, "hello world", false);
 ```
@@ -134,6 +133,8 @@ Note that you have to wrap "unprotected commas" in parentheses:
 ```c++
 dbg("a vector:", (std::vector<int>{2, 3, 4}));
 ```
+
+If you want to output expressions each on its own line write `dbg(x); dbg(y); dbg(z);` instead of `dbg(x, y, z)`.
 
 ### Hexadecimal, octal and binary format
 

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -67,22 +67,47 @@ TEST_CASE("side effects") {
 }
 
 TEST_CASE("multiple arguments") {
-  SECTION("output format") {
-    // The output of dbg(x, y) should be same as dbg(x); dbg(y).
+#ifndef DBG_MACRO_DISABLE
+  SECTION("outputs each argument") {
+    // The output of dbg(x, y, z) should print all arguments.
     std::stringstream ss;
     const auto orig_buf = std::cerr.rdbuf(ss.rdbuf());
-    // Put multiple statements in the same line to get exactly same output.
-    // clang-format off
-    dbg(42); dbg("test"); dbg(42, "test");
-    // clang-format on
+    int aaa = 111, bbb = 222, ccc = 333;
+    dbg(aaa, bbb, ccc);
     std::cerr.rdbuf(orig_buf);
 
-    std::string lines[4];
-    for (int i = 0; i < 4; i++) {
+    std::string line;
+    std::getline(ss, line);
+
+    auto pos = line.find("aaa");
+    CHECK(pos != std::string::npos);
+    pos = line.find("111", pos);
+    CHECK(pos != std::string::npos);
+    pos = line.find("bbb", pos);
+    CHECK(pos != std::string::npos);
+    pos = line.find("222", pos);
+    CHECK(pos != std::string::npos);
+    pos = line.find("ccc", pos);
+    CHECK(pos != std::string::npos);
+    pos = line.find("333", pos);
+    CHECK(pos != std::string::npos);
+  }
+#endif  // DBG_MACRO_DISABLE
+
+  SECTION("output single line") {
+    // The output of dbg(x, y) should fit on one line.
+    std::stringstream ss;
+    const auto orig_buf = std::cerr.rdbuf(ss.rdbuf());
+    dbg(42, "test");
+    std::cerr.rdbuf(orig_buf);
+
+    std::string lines[2];
+    for (int i = 0; i < 2; i++) {
       std::getline(ss, lines[i]);
     }
-    CHECK(lines[0] == lines[2]);  // output for 42
-    CHECK(lines[1] == lines[3]);  // output for "test"
+
+    CHECK(lines[1] == "");
+    CHECK(ss.eof());
   }
 
   SECTION("expression") {


### PR DESCRIPTION
Multiple arguments passed to dbg(...) macro will be printed all on a single line instead of each argument being printed on a separate line.

Resolves #139.