### PR TITLE
Add DBG_MACRO_NO_TYPES flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ int main() {
 * Set the `DBG_MACRO_DISABLE` flag to disable the `dbg(…)` macro (i.e. to make it a no-op).
 * Set the `DBG_MACRO_NO_WARNING` flag to disable the *"'dbg.h' header is included in your code base"* warnings.
 * Set the `DBG_MACRO_FORCE_COLOR` flag to force colored output and skip tty checks.
+* Set the `DBG_MACRO_NO_TYPES` flag to disable the printing of types.
 
 ## Advanced features
 

--- a/dbg.h
+++ b/dbg.h
@@ -888,9 +888,11 @@ class DebugOutput {
       output << ansi(ANSI_EXPRESSION) << *expr << ansi(ANSI_RESET) << " = ";
     }
     output << ansi(ANSI_VALUE) << stream_value.str() << ansi(ANSI_RESET);
+    #ifndef DBG_MACRO_NO_TYPES
     if (print_expr_and_type) {
       output << " (" << ansi(ANSI_TYPE) << *type << ansi(ANSI_RESET) << ")";
     }
+    #endif
     if (close_line) {
       output << std::endl;
     } else {


### PR DESCRIPTION
When printing many variables, printing the types might create a lot of clutter. This simple PR adds support for a new DBG_MACRO_NO_TYPES flag that disables the printing of types.